### PR TITLE
Fix Android Google Maps SDK crash and add proper API key configuration

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     </intent>
   </queries>
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:supportsRtl="true" android:enableOnBackInvokedCallback="false">
+    <meta-data android:name="com.google.android.geo.API_KEY" android:value="@string/google_maps_api_key" />
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,6 +1,11 @@
 <resources>
   <string name="app_name">Suqya Tech</string>
+
+  <!-- Expo defaults -->
   <string name="expo_system_ui_user_interface_style" translatable="false">automatic</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
+
+  <!-- Google Maps SDK Key -->
+  <string name="google_maps_api_key">AIzaSyBRF8qX1KhVDDjtuUc0SWkmpejaG8f4Ca8</string>
 </resources>

--- a/app.json
+++ b/app.json
@@ -29,7 +29,11 @@
       "package": "com.anonymous.starterkitexpo",
       "googleMaps": {
         "apiKey": "AIzaSyBRF8qX1KhVDDjtuUc0SWkmpejaG8f4Ca8"
-      }
+      },
+      "permissions": [
+        "android.permission.ACCESS_COARSE_LOCATION",
+        "android.permission.ACCESS_FINE_LOCATION"
+      ]
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
fix: resolve Google Maps SDK crash on Android by adding API key configuration

- Added google_maps_api_key to `strings.xml`
- Inserted `com.google.android.geo.API_KEY` meta-data in AndroidManifest
- Cleaned Android build caches and rebuilt project
- Disabled new architecture to fix CMake/codegen issues
- Ensured MapView loads without API key crash

Fixes: `java.lang.IllegalStateException:` API key not found