### PR TITLE
Fix transaction update API endpoint path

### DIFF
--- a/api/transaction.ts
+++ b/api/transaction.ts
@@ -38,7 +38,7 @@ export const fetchTripTransaction = async (
 export const updateTransaction = async (transactionId: string, body: any) => {
   return (
     await api.patch<{ doc: Transaction; message: string }>(
-      `/${collection}/endpoint/${transactionId}`,
+      `/${collection}/${transactionId}`,
       body,
     )
   ).data;


### PR DESCRIPTION
fix(transaction): use correct update endpoint path

Previously the client was calling `/{collection}/endpoint/{id}` which does not
exist on the backend and was returning 404 during offline sync.

Updated the URL to `/{collection}/{id}` so transaction updates use the correct
API route and sync no longer fails.